### PR TITLE
ci: add GitHub Actions-based CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+# This is based on the workflow example from https://github.com/erikmd/docker-coq-github-action-demo
+
+name: CI
+
+# Controls when the action will run:
+# https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#filtering-for-specific-branches-tags-and-paths
+# Triggers the workflow on push events for the master branch only,
+# or all pull request events:
+on:
+  push:
+    branches:
+      - master
+      - dev
+  pull_request:
+    branches:
+      - '**'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+# This workflow contains two jobs, build and mathcomp:
+jobs:
+  # The type of runner that the job will run on;
+  # the OS must be GNU/Linux to be able to use the docker-coq-action
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - mathcomp/mathcomp:1.11.0-coq-8.11
+          - mathcomp/mathcomp:1.11.0-coq-8.12
+          - mathcomp/mathcomp-dev:coq-dev
+      max-parallel: 4
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - uses: coq-community/docker-coq-action@v1
+        with:
+          opam_file: './coq-event-struct.opam'
+          custom_image: ${{ matrix.image }}
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Event Structures Formalization
+
+![GitHub Actions][github-actions-badge]
+
+[github-actions-badge]: https://github.com/volodeyka/event-struct/workflows/CI/badge.svg
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras at nisl mattis,
+convallis velit sed, accumsan leo. Fusce sed dui est. Nullam suscipit tincidunt
+ipsum id accumsan. Sed eget sapien ornare magna fermentum blandit. Maecenas
+commodo porttitor leo, at pellentesque nulla imperdiet vel. Ut iaculis, lectus
+eget sodales bibendum, justo nulla posuere augue, eu rutrum turpis dui ac erat.
+Donec pharetra elit vitae tincidunt vestibulum. Sed iaculis facilisis ipsum sed
+aliquam. Nullam tincidunt purus sed est pulvinar lacinia. Integer at nunc vitae
+sem pulvinar maximus quis in ipsum. Duis ut sem varius, ultrices leo vel,
+interdum orci. Etiam bibendum varius lectus ac scelerisque. Nam in magna sapien.
+Nunc mattis orci non risus rutrum posuere. Mauris nec viverra lectus.
+

--- a/_CoqProject
+++ b/_CoqProject
@@ -5,6 +5,7 @@
 -arg -w -arg -non-reversible-notation
 -arg -w -arg -duplicate-clear
 -arg -w -arg -redundant-canonical-projection
+-arg -w -arg  -notation-incompatible-format
 
 utilities.v
 EventStructure.v

--- a/coq-event-struct.opam
+++ b/coq-event-struct.opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "volodeyka@gmail.com"
+version: "dev"
+
+homepage: "https://github.com/volodeyka/event-struct"
+dev-repo: "git+https://github.com/volodeyka/event-struct.git"
+bug-reports: "https://github.com/volodeyka/event-struct/issues"
+doc: "https://volodeyka.github.io/event-struct/"
+license: "TODO: MIT recommended"
+
+synopsis: "Formalization of event structures in Coq"
+description: """
+TODO
+Blah-blah-blah."""
+
+build: [make "-j%{jobs}%" ]
+install: [make "install"]
+depends: [
+  "coq" {(>= "8.10" & < "8.13~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.11" & < "1.12~") | (= "dev")}
+  "coq-equations"
+]
+conflicts: [
+  "coq-equations" {(= "dev+HoTT")}
+]
+
+tags: [
+  "category:Computer Science/Concurrency"
+  "logpath:event_struct"
+]
+authors: [
+  "TODO"
+]


### PR DESCRIPTION
The documentation on how CI is organized is here: https://github.com/coq-community/docker-coq/wiki/CI-setup.