### PR TITLE
fix(ci): fix finmap version and remove coq.dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,15 @@ jobs:
         image:
           - mathcomp/mathcomp:1.11.0-coq-8.11
           - mathcomp/mathcomp:1.11.0-coq-8.12
-          - mathcomp/mathcomp-dev:coq-dev
+#          - mathcomp/mathcomp-dev:coq-dev
       max-parallel: 4
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
       - uses: coq-community/docker-coq-action@v1
         with:
+          before_install: opam config list; opam repo list;
+           opam list; opam pin add coq-mathcomp-finmap --dev-repo --no-action
           opam_file: './coq-event-struct.opam'
           custom_image: ${{ matrix.image }}
 

--- a/coq-event-struct.opam
+++ b/coq-event-struct.opam
@@ -17,7 +17,7 @@ build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
   "coq" {(>= "8.10" & < "8.13~") | (= "dev")}
-  "coq-mathcomp-finmap"
+  "coq-mathcomp-finmap" {(= "dev")}
   "coq-mathcomp-ssreflect" {(>= "1.11" & < "1.12~") | (= "dev")}
   "coq-equations"
 ]


### PR DESCRIPTION
Here we pinned finmap to dev version via `before_install` in ci.yml
Also we removed coq.dev because it can't compile coq-equations

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volodeyka/event-struct/29)
<!-- Reviewable:end -->
