### PR TITLE
refactor: relpre may be used instead of comp2

### DIFF
--- a/inhtype.v
+++ b/inhtype.v
@@ -55,46 +55,4 @@ End Exports.
 
 End Inhabitant.
 Export Inhabitant.Exports.
-Implicit Type T : inhType.
-
-Section Extension.
-
-Context {T : inhType}.
-Implicit Types (x : T) (n : nat).
-Notation inh := (@inh T).
-
-Definition ext {n} (f : 'I_n -> T) : nat -> T := fun k =>
-  if insub_ord n k is some k then f k else inh.
-
-Lemma ext_add {x n} {f : 'I_n -> T} r : r != n ->
-  ext (add f x) r = ext f r.
-Proof.
-  rewrite /ext. insub_case=> ??; insub_case=> //; try slia.
-  move => L. rewrite add_lt. exact /congr1 /ord_inj.
-Qed.
-
-Lemma ext_add_n  {x n} {f : 'I_n -> T} :
-  ext (add f x) n = x.
-Proof. rewrite /ext. insub_case=> *; try slia. by rewrite add_ord_max. Qed.
-
-Lemma pred_ext {n} (f : 'I_n -> T) (p : pred T) (r : 'I_n) :
- p (ext f r) = p (f r).
-Proof.
-  case: r=> /= *. rewrite /ext. insub_case=> [?|]; try slia.
-  exact /congr1 /congr1 /ord_inj.
-Qed.
-
-Lemma rel_ext {n x} (f : 'I_n -> T) (r : rel T) (a b : nat) :
-   ~ (rfield r inh) -> (r \o2 ext f) a b -> (r \o2 ext (add f x)) a b.
-Proof.
-  rewrite /comp2=> ?. case L: (a < n).
-  { rewrite ext_add //; try slia.
-    case L': (b < n). 
-    { rewrite ext_add //. slia. }
-    rewrite {2}/ext. insub_case=> [? _|_/(codom_rfield r)]; slia. }
-  rewrite {1}/ext. insub_case=> [? _|_/(dom_rfield r)]; slia.
-Qed.
-
-End Extension.
-
 

--- a/utilities.v
+++ b/utilities.v
@@ -4,10 +4,6 @@ From mathcomp Require Import seq path fingraph fintype.
 
 Notation none := None.
 
-Definition comp2 {A B C : Type} (f : B -> B -> A) (g : C -> B) x y := f (g x) (g y).
-
-Notation "f \o2 g" := (comp2 f g) (at level 50) : fun_scope.
-
 (* ******************************************************************************** *)
 (*     Some atomation with Hints, tacticts and iduction scheme                      *)
 (* ******************************************************************************** *)


### PR DESCRIPTION
This commit also removes unused code that depends on `comp2`.
By the way,
```
  (r \o2 ext f) a b -> (r \o2 ext (add f x)) a b
```
can be written as
```
   subrel (relpre (ext f) r) (relpre (ext (add f x)) r)
```
after a bit of reshuffling of the quantifiers.

Upshot: no need to introduce `comp2`, the standard `relpre` could have been reused.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volodeyka/event-struct/43)
<!-- Reviewable:end -->
