### PR TITLE
Remove none notation

### DIFF
--- a/inhtype.v
+++ b/inhtype.v
@@ -55,46 +55,4 @@ End Exports.
 
 End Inhabitant.
 Export Inhabitant.Exports.
-Implicit Type T : inhType.
-
-Section Extension.
-
-Context {T : inhType}.
-Implicit Types (x : T) (n : nat).
-Notation inh := (@inh T).
-
-Definition ext {n} (f : 'I_n -> T) : nat -> T := fun k =>
-  if insub_ord n k is some k then f k else inh.
-
-Lemma ext_add {x n} {f : 'I_n -> T} r : r != n ->
-  ext (add f x) r = ext f r.
-Proof.
-  rewrite /ext. insub_case=> ??; insub_case=> //; try slia.
-  move => L. rewrite add_lt. exact /congr1 /ord_inj.
-Qed.
-
-Lemma ext_add_n  {x n} {f : 'I_n -> T} :
-  ext (add f x) n = x.
-Proof. rewrite /ext. insub_case=> *; try slia. by rewrite add_ord_max. Qed.
-
-Lemma pred_ext {n} (f : 'I_n -> T) (p : pred T) (r : 'I_n) :
- p (ext f r) = p (f r).
-Proof.
-  case: r=> /= *. rewrite /ext. insub_case=> [?|]; try slia.
-  exact /congr1 /congr1 /ord_inj.
-Qed.
-
-Lemma rel_ext {n x} (f : 'I_n -> T) (r : rel T) (a b : nat) :
-   ~ (rfield r inh) -> (r \o2 ext f) a b -> (r \o2 ext (add f x)) a b.
-Proof.
-  rewrite /comp2=> ?. case L: (a < n).
-  { rewrite ext_add //; try slia.
-    case L': (b < n). 
-    { rewrite ext_add //. slia. }
-    rewrite {2}/ext. insub_case=> [? _|_/(codom_rfield r)]; slia. }
-  rewrite {1}/ext. insub_case=> [? _|_/(dom_rfield r)]; slia.
-Qed.
-
-End Extension.
-
 

--- a/regmachine.v
+++ b/regmachine.v
@@ -102,25 +102,25 @@ Definition thrd_sem (st : thrd_state) :
   (option (@label unit val) * (val -> thrd_state))%type :=
   let: {| ip := i; regmap := map |} := st in
   match nth p i with
-  | WriteReg v r => (none,
+  | WriteReg v r => (None,
                      fun _ => {| ip     := i.+1;
                                  regmap := [fsfun map with r |-> v] |})
-  | ReadLoc  r x => (some (Read x __), 
+  | ReadLoc  r x => (Some (Read x __),
                      fun v => {| ip     := i.+1;
                                  regmap := [fsfun map with r |-> v] |})
-  | WriteLoc v x => (some (Write x v), 
+  | WriteLoc v x => (Some (Write x v),
                      fun _ => {| ip     := i.+1;
                                  regmap := map |})
-  | CJmp     r n => (none,             
+  | CJmp     r n => (None,
                      fun _ => {| ip     := if map r != inh then n else i.+1;
                                  regmap := map |} )
   end.
 
 Definition ltr_thrd_sem (l : option (@label val val)) st1 st2 : bool :=
   match thrd_sem st1, l with
-  | (some (Write x v), st), some (Write y u) => [&& x == y, v == u & st inh == st2]
-  | (some (Read  x _), st), some (Read  y u) => (x == y) && (st u == st2)
-  | (none            , st), none             => st inh == st2
+  | (Some (Write x v), st), Some (Write y u) => [&& x == y, v == u & st inh == st2]
+  | (Some (Read  x _), st), Some (Read  y u) => (x == y) && (st u == st2)
+  | (None            , st), None             => st inh == st2
   | _, _                                     => false
   end.
 
@@ -139,16 +139,16 @@ Definition wval (l : @label val val) : val :=
 (* label location *)
 Definition lloc (l : @label val val) := 
   match l with
-  | Write x _ => some x
-  | Read  x _ => some x
-  | _         => none
+  | Write x _ => Some x
+  | Read  x _ => Some x
+  | _         => None
   end.
 
 Definition is_write (l : @label val val) := 
   if l is Write _ _ then true else false.
 
 Definition wpred (x : loc) (w : E) :=
-   (lloc (lab w) == some x) && (is_write (lab w)).
+   (lloc (lab w) == Some x) && (is_write (lab w)).
 
 Arguments wpred /.
 
@@ -194,7 +194,7 @@ Definition add_hole
 Definition eval_step (c : config) {pr} (pr_mem : pr \in fresh_id :: dom) 
   : seq config :=
   let: (l, cont_st) := thrd_sem (c pr) in
-  if l is some l then
+  if l is Some l then
     [seq let: (e, v) := x in 
           (Config e [fsfun c with fresh_id |-> cont_st v]) |
           x <- (add_hole l pr_mem)]

--- a/utilities.v
+++ b/utilities.v
@@ -4,10 +4,6 @@ From mathcomp Require Import seq path fingraph fintype.
 
 Notation none := None.
 
-Definition comp2 {A B C : Type} (f : B -> B -> A) (g : C -> B) x y := f (g x) (g y).
-
-Notation "f \o2 g" := (comp2 f g) (at level 50) : fun_scope.
-
 (* ******************************************************************************** *)
 (*     Some atomation with Hints, tacticts and iduction scheme                      *)
 (* ******************************************************************************** *)

--- a/utilities.v
+++ b/utilities.v
@@ -2,8 +2,6 @@ From Coq Require Import Lia Relations.
 From mathcomp Require Import ssreflect ssrbool ssrnat ssrfun eqtype.
 From mathcomp Require Import seq path fingraph fintype.
 
-Notation none := None.
-
 (* ******************************************************************************** *)
 (*     Some atomation with Hints, tacticts and iduction scheme                      *)
 (* ******************************************************************************** *)
@@ -269,13 +267,6 @@ Proof.
 Qed.
 
 End upgrade.
-
-Definition insub_ord (n k : nat) : option 'I_n := 
-  (if k < n as L return (k < n = L -> _) then
-   fun pf => some (ord pf)
-   else fun=> none) erefl.
-
-Ltac insub_case := rewrite /insub_ord; dcase=> //=.
 
 Lemma refleqP {a b A B} (rA : reflect A a) (rB : reflect B b) :
   A <-> B -> a = b.


### PR DESCRIPTION
This removes spurious `none` notation.
And refactors `some` to `Some` because `some` is intended
to be used as a function passed to higher-order functions.

This PR is a follow-up of #43

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volodeyka/event-struct/44)
<!-- Reviewable:end -->
