### PR TITLE
refactor: logical lemmas from utilities

### DIFF
--- a/eventstructure.v
+++ b/eventstructure.v
@@ -180,7 +180,7 @@ Arguments clos_rt1n_rt {_ _ _ _}.
 (* Causality relation *)
 Definition ca : rel E := rt_closure fica fica_le.
 
-Lemma closureP e1 e2: 
+Lemma closureP {e1 e2} :
   reflect (clos_refl_trans_n1 _ ica e1 e2) (ca e1 e2).
 Proof. exact/(equivP (rt_closure_n1P _ _ _ _)). Qed.
 
@@ -402,3 +402,5 @@ End PrimeEventStructure.
 (*Notation "x <c= y" := (@Order.le ev_display _ x y) (at level 10).*)
 Notation "a # b" := (cf _ a b) (at level 10).
 Notation "w << r" := (write_read_from w r) (at level 0). 
+
+Arguments cfP {val disp E es e1 e2}.

--- a/utilities.v
+++ b/utilities.v
@@ -199,16 +199,9 @@ Proof. by rewrite -[in RHS](sval_seq_in_sub s s') map_pK //; apply: valK. Qed.
 End SeqIn.
 
 
-Lemma refleqP {a b A B} (rA : reflect A a) (rB : reflect B b) :
-  A <-> B -> a = b.
-Proof. case=> *; exact /(sameP rA)/(iffP rB). Qed.
-
-Lemma exists_eq {T} {A B : T -> Prop} (_ : forall x, A x <-> B x) : 
-  (exists x, A x) <-> exists x, B x.
-Proof. split=> [][] x /H ?; by exists x. Qed.
-
-Lemma and_eq (a b c : bool): (a -> (b = c)) -> (a && b = a && c).
-Proof. by case: a=> // /(_ erefl) ->. Qed.
+Lemma exists_equiv {T} {A B : T -> Prop} :
+  (forall x, A x <-> B x) -> (exists x, A x) <-> exists x, B x.
+Proof. move=> H; split=> [][] x /H ?; by exists x. Qed.
 
 Lemma clos_reflE {T} {R : relation T} a b :
   clos_refl T R a b <-> (a = b) \/ R a b.


### PR DESCRIPTION
- Removed `refleqP` because it repeats the idiomatic `apply/view1/view2` tactic.

- Changed the implicit status of the arguments of a couple of view lemmas.
  In general, `reflect`-lemmas should have their "simple" arguments maximally-inserted implicit.

- Renamed `exists_eq` into `exists_equiv`.

- Removed `and_eq` lemma because it's `andb_id2l` from ssrbool.v.

- Added two helper lemmas about causality and freshness.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volodeyka/event-struct/51)
<!-- Reviewable:end -->
