### PR TITLE
refactor: minimize imports and reorganize them a bit

### DIFF
--- a/eventstructure.v
+++ b/eventstructure.v
@@ -363,7 +363,7 @@ Qed.
 Lemma cf_irrelf : irreflexive cf.
 Proof.
   move=> m; apply/negbTE/negP.
-  elim/(@wf_ind disp E): m=> m IHn.
+  elim/(@wfb_ind disp E): m=> m IHn.
   suff C: ~ m # (fpred m).
   - by rewrite cfE /icf=> /or3P[/andP[/eqP]||] //= /or3P[]// /rff_consist.
   move=> /cfP[x [y /and3P[]]]; case Eq: (x == m).

--- a/eventstructure.v
+++ b/eventstructure.v
@@ -1,6 +1,6 @@
 From Coq Require Import Relations.
-From mathcomp Require Import ssreflect ssrnat ssrfun ssrbool seq fintype order.
-From mathcomp Require Import eqtype fingraph path tuple finmap finfun choice.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq path.
+From mathcomp Require Import eqtype choice order finmap.
 From event_struct Require Import utilities relations rfsfun wftype ident.
 
 (******************************************************************************)

--- a/ident.v
+++ b/ident.v
@@ -1,6 +1,6 @@
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
-From mathcomp Require Import order choice finmap.
-From event_struct Require Import wftype utilities.
+From mathcomp Require Import order choice.
+From event_struct Require Import utilities wftype.
 
 (******************************************************************************)
 (* This file contains the definitions of:                                     *)
@@ -19,7 +19,6 @@ From event_struct Require Import wftype utilities.
 
 Import Order.LTheory.
 Open Scope order_scope.
-Open Scope fset_scope.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/regmachine.v
+++ b/regmachine.v
@@ -1,5 +1,5 @@
-From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq fintype order.
-From mathcomp Require Import eqtype fingraph path finmap choice finfun. 
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From mathcomp Require Import eqtype choice finfun finmap.
 From event_struct Require Import utilities eventstructure inhtype.
 From event_struct Require Import transitionsystem ident rfsfun.
 

--- a/relations.v
+++ b/relations.v
@@ -1,6 +1,5 @@
-From Coq Require Import Lia.
-From Coq Require Import Relations Relation_Operators Program.Basics.
-From mathcomp Require Import ssreflect ssrbool eqtype ssrfun seq order.
+From Coq Require Import Relations Relation_Operators.
+From mathcomp Require Import ssreflect ssrbool ssrfun eqtype seq order.
 From Equations Require Import Equations.
 From event_struct Require Import utilities wftype.
 

--- a/rfsfun.v
+++ b/rfsfun.v
@@ -1,5 +1,5 @@
-From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq fintype choice.
-From mathcomp Require Import eqtype fingraph path order tuple path finmap finfun finset. 
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq.
+From mathcomp Require Import choice fintype finset finmap.
 From event_struct Require Import utilities.
 
 (******************************************************************************)

--- a/transitionsystem.v
+++ b/transitionsystem.v
@@ -1,6 +1,5 @@
-From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq fintype order.
-From mathcomp Require Import eqtype fingraph path finmap. 
-From event_struct Require Import utilities relations ident rfsfun.
+From mathcomp Require Import ssreflect ssrfun ssrbool seq eqtype order finmap.
+From event_struct Require Import utilities ident rfsfun.
 From event_struct Require Import eventstructure.
 
 (******************************************************************************)

--- a/wftype.v
+++ b/wftype.v
@@ -1,27 +1,22 @@
-From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq fintype.
-From mathcomp Require Import eqtype fingraph path order choice. 
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat.
+From mathcomp Require Import eqtype choice order.
 Require Import Equations.Prop.Loader.
-From event_struct Require Import utilities.
 
 (******************************************************************************)
 (* This file contains the definitions of:                                     *)
-(*       wfType d == the structure for types with well-founded partial order. *)
-(*       well_founded_bool r == r is decidable well-founded relation          *)
-(*       wf == the well-founded order of wfType                               *)
-(*       wf_ind == well-founded induction for wfType                          *)
-(* This file also contains canonical instance of wfType for nat               *) 
+(*             wfType d == the structure for types with                       *)
+(*                         well-founded partial order.                        *)
+(*  well_founded_bool r <-> r is a decidable well-founded relation.           *)
+(*                  wfb <-> wfType's order relation is well-founded.          *)
+(*              wfb_ind <-> well-founded induction principle for wfType.      *)
+(* This file also contains canonical instance of wfType for nat.              *)
 (******************************************************************************)
 
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import Order.LTheory.
-Open Scope order_scope.
-
-Notation ordType := (orderType tt).
-
-Section WfDef.
+Section WfBool.
 
 Context {T : Type} (r : rel T).
 
@@ -30,7 +25,9 @@ Inductive acc_bool (x : T) :=
 
 Definition well_founded_bool := forall x, acc_bool x.
 
-End WfDef.
+End WfBool.
+
+Open Scope order_scope.
 
 Module WellFounded.
 
@@ -39,7 +36,7 @@ Section ClassDef.
 Record mixin_of T0 (b : Order.POrder.class_of T0)
   (T := Order.POrder.Pack tt b) := Mixin {
   _ : well_founded_bool (<%O : rel T);
-}. 
+}.
 
 Set Primitive Projections.
 
@@ -84,46 +81,38 @@ Canonical choiceType.
 Canonical porderType.
 Notation WfType disp T m := (@pack T disp _ _ id m).
 
-
 End Exports.
 
 End WellFounded.
 
 Export WellFounded.Exports.
 
+
 Section WfInduction.
 
 Context {disp : unit} {T : wfType disp}.
 
-Lemma wf : well_founded_bool (<%O : rel T).
+Lemma wfb : well_founded_bool (<%O : rel T).
 Proof. by case: T=> ? [] ? []. Qed.
 
-Lemma wf_ind (P : T -> Type) :
+Lemma wfb_ind (P : T -> Type) :
   (forall n, (forall m, m < n -> P m) -> P n) ->
   forall n, P n.
-Proof.
-  move=> accP M.
-  by elim: (wf M) => ?? /accP. 
-Qed.
+Proof. by move=> accP M; elim: (wfb M) => ?? /accP. Qed.
 
 End WfInduction.
 
-Global Instance wf_wfType {disp : unit} {T : wfType disp} : 
+Global Instance wf_wfType {disp : unit} {T : wfType disp} :
   Equations.Prop.Classes.WellFounded (<%O : rel T).
-Proof. apply: wf_ind. by constructor. Qed.
+Proof. by apply: wfb_ind; constructor. Qed.
 
-Section NatWellFounded.
 
-Lemma nat_well_founded_bool:  well_founded_bool (<%O : rel nat).
-Proof.
-  elim=> [//|n /[dup] ? [IHn]].
-  constructor=> m; case E: (n == m)=> /= L; first by move/eqP: E=> <-.
-  apply/IHn=> /=. move: L. rewrite /Order.lt /=. ssrnatlia.
-Qed.
-
-End NatWellFounded.
+(* Canonical well-founded order for nat *)
 
 Import Order.NatOrder.
+
+Lemma nat_well_founded_bool:  well_founded_bool (<%O : rel nat).
+Proof. by elim/ltn_ind=> n IHn; constructor=> m /IHn. Qed.
 
 Definition nat_wfMixin := @WellFounded.Mixin nat _ nat_well_founded_bool.
 Canonical nat_wfType := Eval hnf in WfType nat_display nat nat_wfMixin.


### PR DESCRIPTION
This PR's scope is just imports across the whole project nothing else has been touched.
This simplifies the project's dependency graph and should speed compilation time a bit (not that it matters in our particular case).

Partly done using https://github.com/JasonGross/coq-tools
```
coq-tools/minimize-requires.py --all -f _CoqProject
```
and partly manually.

This PR depends on #53 (I noticed there is room for import refactoring while working on #53).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volodeyka/event-struct/54)
<!-- Reviewable:end -->
