### PR TITLE
Relation refactor and some Relation-Algebra Integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
     strategy:
       matrix:
         image:
-          - mathcomp/mathcomp:1.11.0-coq-8.11
-          - mathcomp/mathcomp:1.11.0-coq-8.12
+          - mathcomp/mathcomp:1.12.0-coq-8.11
+          - mathcomp/mathcomp:1.12.0-coq-8.12
           - mathcomp/mathcomp:1.12.0-coq-8.13
           - mathcomp/mathcomp-dev:coq-dev
       max-parallel: 4

--- a/coq-event-struct.opam
+++ b/coq-event-struct.opam
@@ -20,7 +20,7 @@ install: [make "install"]
 depends: [
   "coq" {(>= "8.10" & < "8.14~") | (= "dev")}
   "coq-mathcomp-finmap" {(>= "1.5.1")}
-  "coq-mathcomp-ssreflect" {(>= "1.11" & < "1.13~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.12" & < "1.13~") | (= "dev")}
   "coq-equations"
   "coq-relation-algebra" {(>= "1.7.4")}
 ]

--- a/eventstructure.v
+++ b/eventstructure.v
@@ -201,14 +201,6 @@ Arguments clos_rt1n_rt {_ _ _ _}.
 (* Causality relation *)
 Definition ca : rel E := (rt_closure fica_gt)°.
 
-Lemma helper2 {T : eqType} (r : rel T) :
-  (r \ eq_op : hrel T T) ≡ (r : hrel T T) \ eq.
-Proof. 
-  move=> x y /=; symmetry. 
-  rewrite andbC and_comm. 
-  by apply (rwP predD1P).
-Qed.
-
 Lemma closureP {e1 e2} :
   reflect (clos_refl_trans _ ica e1 e2) (ca e1 e2).
 Proof.

--- a/relations.v
+++ b/relations.v
@@ -76,18 +76,6 @@ Definition t_closure : rel T :=
 Definition rt_closure : rel T := 
   fun x y => y \in wsuffix x. 
 
-Lemma clos_trans_1n_lt : 
-  clos_trans_1n T (sfrel f) ≦ (>%O : rel T).
-Proof.
-  move=> ??. rewrite/sfrel //=. 
-  elim=> [y z /descend | x y z /descend ] //=.
-  move=> /[swap] _ /[swap]. exact: lt_trans.
-Qed.
-
-Lemma clos_trans_lt : 
-  clos_trans T (sfrel f) ≦ (>%O : rel T).
-Proof. by move=> x y ct //=; apply /clos_trans_1n_lt /clos_trans_t1n. Qed.
-
 (* Transitive closure reflection lemma *)
 Lemma t_closure_1nP x y : 
   reflect (clos_trans_1n T (sfrel f) x y) (t_closure x y).
@@ -101,7 +89,7 @@ Proof.
   move=> H; case: H; clear y. 
   { by move=> y ?; apply /orP; left. }
   move=> y z yin /X Hz; apply /orP; right; apply /flatten_mapP. 
-  case: (seq_in_mem_xx _ _ yin)=> y' yval' yin'.
+  case: (seq_in_mem_exist _ _ yin)=> y' yval' yin'.
   eexists; first by exact yin'.
   by rewrite -yval'; apply /Hz /descend.
 Qed.
@@ -113,12 +101,20 @@ Proof.
   apply /t_closure_1nP; exact: clos_trans_t1n.
 Qed.
 
-Lemma t_closure_lt : t_closure ≦ (>%O : rel T).
-Proof. by move=> x y /t_closureP /clos_trans_lt. Qed.
+Lemma clos_trans_gt : 
+  clos_trans T (sfrel f) ≦ (>%O : rel T).
+Proof. 
+  move=> ??. rewrite/sfrel //=. 
+  elim=> [y z /descend | x y z _ ] //=.
+  move=> /[swap] _ /[swap]; exact: lt_trans.
+Qed.
+
+Lemma t_closure_gt : t_closure ≦ (>%O : rel T).
+Proof. by move=> x y /t_closureP /clos_trans_gt. Qed.
 
 Lemma t_closure_antisym : antisymmetric t_closure.
 Proof.
-  move=> x y /andP[] /t_closure_lt ? /t_closure_lt ?. 
+  move=> x y /andP[] /t_closure_gt ? /t_closure_gt ?. 
   by apply /eqP; rewrite eq_le !ltW.
 Qed.
 
@@ -145,11 +141,11 @@ Proof.
   by rewrite /wsuffix in_cons eq_sym.
 Qed.
 
-Lemma rt_closure_lt : rt_closure ≦ (>=%O : rel T).
+Lemma rt_closure_ge : rt_closure ≦ (>=%O : rel T).
 Proof.
   rewrite rt_closureE.
   move=> x y /orP[/eqP[<-]|] //=.
-  move=> /t_closure_lt; exact: ltW.
+  move=> /t_closure_gt; exact: ltW.
 Qed.
 
 Lemma rt_closure_refl x : rt_closure x x.
@@ -158,7 +154,7 @@ Proof. exact: mem_head. Qed.
 Lemma rt_closure_antisym : antisymmetric rt_closure.
 Proof.
   move=> x y /andP[]. 
-  move=> /rt_closure_lt /= xy /rt_closure_lt /= yx. 
+  move=> /rt_closure_ge /= xy /rt_closure_ge /= yx. 
   by apply /eqP; rewrite eq_le xy yx.
 Qed.
 

--- a/relations.v
+++ b/relations.v
@@ -1,5 +1,6 @@
 From Coq Require Import Relations Relation_Operators.
 From mathcomp Require Import ssreflect ssrbool ssrfun eqtype seq order.
+From RelationAlgebra Require Import lattice rel.
 From Equations Require Import Equations.
 From event_struct Require Import utilities wftype.
 
@@ -9,199 +10,162 @@ Set Equations Transparent.
 
 Import Order.LTheory.
 Local Open Scope order_scope.
+(* Local Open Scope ra_terms. *)
 
-Section well_founded.
+(* a hack to bypass a shadowing problem caused by relation-algebra import *)
+Local Notation antisymmetric  := Coq.ssr.ssrbool.antisymmetric.
+Local Notation transitive := Coq.ssr.ssrbool.transitive.
 
-Definition sfrel {T : eqType} (f : T -> seq T) : rel T :=
-  [rel a b | a \in f b].
+Section SeqFunRel.
 
-Definition strict {T : eqType} (f : T -> seq T) : T -> seq T :=
+Context {T : eqType}.
+
+Definition sfrel (f : T -> seq T) : rel T := [rel a b | b \in f a].
+
+Definition strictify (f : T -> seq T) : T -> seq T :=
   fun n => filter^~ (f n) (fun x => x != n).
 
-Notation "f '\eq'" := (strict f) (at level 5, format "f '\eq'").
+Lemma strictify_weq (f : T -> seq T) :
+  sfrel (strictify f) ≡ (sfrel f \ eq_op).
+Proof. 
+  move=> x y. rewrite /sfrel /strictify //=.
+  by rewrite /=mem_filter andbC eq_sym.
+Qed.
 
-Lemma strict_in_sfrel {T : eqType} (f : T -> seq T) a b : 
-  sfrel f\eq a b -> sfrel f a b.
-Proof. by rewrite /strict /sfrel /= mem_filter => /andP[]. Qed.
+Lemma strictify_leq (f : T -> seq T) : 
+  sfrel (strictify f) ≦ sfrel f.
+Proof. by rewrite strictify_weq; lattice. Qed.
 
-Lemma in_strict {T : eqType} (f : T -> seq T) a b :
-  (a != b) -> (a \in f b) -> ((sfrel f\eq) a b).
-Proof. by rewrite /sfrel /strict /= mem_filter => -> ->. Qed. 
+End SeqFunRel.
 
-Hint Resolve strict_in_sfrel in_strict : core.
+Section DescendRTClos.
 
 Context {disp : unit} {T : wfType disp}.
 
 Variable (f : T -> seq T).
 
-Hypothesis descend : forall x n, x \in f n -> x <= n.
+(* Hypothesis descend : forall x y, y \in f x -> y < x. *)
+Hypothesis descend : sfrel f ≦ (>%O).
 
-Lemma strict_lt n k : k \in f\eq n -> k < n.
-Proof. by rewrite mem_filter lt_neqAle => /andP[] -> /descend ->. Qed.
-
-Hint Resolve strict_lt : core.
-
-Lemma rel_sublt a b : (sfrel f\eq) a b -> a < b.
-Proof. rewrite/sfrel /=. exact: strict_lt. Qed.
-
-Definition s_up_set_aux n (g : forall x : T, x < n -> seq T) := 
-  let ys := f\eq n in 
-  let ps := flatten (map^~ ys (fun x => 
-  if x \in ys =P true is ReflectT pf then
-    g x (strict_lt _ _ pf)
-  else
-    [::]
-)) in ys ++ ps.
-
-Arguments s_up_set_aux /.
-
-(* Computation of the strict upward set of a given element
- * w.r.t relation R derived from function `f`,
- * i.e. s_up_set(x) = { y | x R y } 
+(* A hack to get around a bug in Equations 
+ * (see https://github.com/mattam82/Coq-Equations/issues/241).
+ * In short, we cannot express this function directly in Equations' syntax
+ * (we can do it by adding `noind` specifier, but then we cannot use `funelim`).
+ * Thus we have to "tie a recursive knot" manually. 
  *)
-Equations s_up_set (n : T) : seq T by wf n (<%O : rel T) :=
-  s_up_set n := s_up_set_aux n s_up_set.
+Definition suffix_aux (x : T) (rec : forall y : T, y < x -> seq T) := 
+  let ys := f x in 
+  let ps := flatten (map^~ (seq_in ys) (fun y => 
+    rec (val y) (descend _ _ (valP y))
+  )) 
+  in ys ++ ps.
 
-Definition t_closure (a b : T) : bool := a \in s_up_set b.
+(* strict suffix of an element `x`, i.e. a set { y | x < y } *)
+Equations suffix (x : T) : seq T by wf x (<%O : rel T) := 
+  suffix x := suffix_aux x suffix.
 
-Lemma clos_trans_n1_lt a b : clos_trans_n1 T (sfrel f\eq) a b -> a < b.
+(* weak suffix of an element `x`, i.e. a set { y | x <= y } *)
+Definition wsuffix (x : T) : seq T :=
+  x :: suffix x.
+
+(* decidable transitive closure *)
+Definition t_closure : rel T := 
+  fun x y => y \in suffix x.
+
+(* decidable reflexive-transitive closure *)
+Definition rt_closure : rel T := 
+  fun x y => y \in wsuffix x. 
+
+Lemma clos_trans_1n_lt : 
+  clos_trans_1n T (sfrel f) ≦ (>%O : rel T).
 Proof.
-  rewrite/sfrel //=.
-  elim=> [x| x y xfy acx ax]. auto.
-  apply: lt_trans; first exact: ax. auto.
+  move=> ??. rewrite/sfrel //=. 
+  elim=> [y z /descend | x y z /descend ] //=.
+  move=> /[swap] _ /[swap]. exact: lt_trans.
 Qed.
 
-Lemma clos_trans_lt a b : clos_trans T (sfrel f\eq) a b -> a < b.
-Proof. move=> cab. by apply /clos_trans_n1_lt /clos_trans_tn1. Qed.
+Lemma clos_trans_lt : 
+  clos_trans T (sfrel f) ≦ (>%O : rel T).
+Proof. by move=> x y ct //=; apply /clos_trans_1n_lt /clos_trans_t1n. Qed.
 
 (* Transitive closure reflection lemma *)
-Lemma t_closure_n1P a b : 
-  reflect (clos_trans_n1 T (sfrel f\eq) a b) (t_closure a b).
+Lemma t_closure_1nP x y : 
+  reflect (clos_trans_1n T (sfrel f) x y) (t_closure x y).
 Proof.
-  rewrite /t_closure. funelim (s_up_set b)=> /=. 
+  rewrite /t_closure. funelim (suffix x)=> /=. 
   apply /(iffP idP); rewrite mem_cat /sfrel /=.
-  { move=> /orP[|/flatten_mapP[x]] //; first exact: tn1_step.
-    case: eqP=> // S /strict_lt/X/(_ a x erefl) /[apply]. exact: tn1_trans. }
-  move: X=> /[swap] [[?->//|y ? /[dup] ? L /[swap]]].
-  move=> /[apply] ?; apply/orP; right; apply/flatten_mapP.
-  exists y=> //. case: eqP; auto.
+  { move=> /orP[|/flatten_mapP[z]] //=; first exact: t1n_step.
+    move=> zin' yin. have zin: (val z \in f x) by apply /seq_in_mem /zin'.
+    apply: t1n_trans; first exact zin.
+    apply: X; last exact: yin. by apply descend. }
+  move=> H; case: H; clear y. 
+  { by move=> y ?; apply /orP; left. }
+  move=> y z yin /X Hz; apply /orP; right; apply /flatten_mapP. 
+  case: (seq_in_mem_xx _ _ yin)=> y' yval' yin'.
+  eexists; first by exact yin'.
+  by rewrite -yval'; apply /Hz /descend.
 Qed.
-
-Lemma t_closureP a b :
-  reflect (clos_trans T (sfrel f\eq) a b) (t_closure a b).
+  
+Lemma t_closureP x y :
+  reflect (clos_trans T (sfrel f) x y) (t_closure x y).
 Proof.
-  apply /(iffP idP) => [/t_closure_n1P| cab]; first exact: clos_tn1_trans.
-  apply /t_closure_n1P. exact: clos_trans_tn1.
+  apply /(iffP idP) => [/t_closure_1nP| cab]; first exact: clos_t1n_trans.
+  apply /t_closure_1nP; exact: clos_trans_t1n.
 Qed.
 
-Lemma t_closure_lt a b : t_closure a b -> a < b.
-Proof. by move=> /t_closureP /clos_trans_lt. Qed.
-
-Lemma t_closure_trans : transitive t_closure.
-Proof.
-  move=> b a c /t_closureP ab /t_closureP bc.
-  apply /t_closureP /t_trans; first exact: ab. exact: bc.
-Qed.
+Lemma t_closure_lt : t_closure ≦ (>%O : rel T).
+Proof. by move=> x y /t_closureP /clos_trans_lt. Qed.
 
 Lemma t_closure_antisym : antisymmetric t_closure.
 Proof.
-  move=> a b /andP[] /t_closure_lt ab /t_closure_lt ba. apply /eqP.
-  by rewrite eq_le !ltW.
+  move=> x y /andP[] /t_closure_lt ? /t_closure_lt ?. 
+  by apply /eqP; rewrite eq_le !ltW.
 Qed.
 
-(* Computation of the (non-strict) upward set of a given element
- * w.r.t relation R derived from function `f`,
- * i.e. up_set(x) = { y | x = y \/ x R y } 
- *)
-Definition up_set a := a :: s_up_set a.
-
-Definition rt_closure a b := a \in up_set b. 
-
-Lemma rt_closure_reflP a b :
-  reflect (clos_refl T t_closure a b) (rt_closure a b).
+Lemma t_closure_trans : transitive t_closure.
 Proof.
-  rewrite /rt_closure /up_set. funelim (s_up_set b).
-  apply /(iffP idP).
-  { rewrite -cat_cons mem_cat in_cons => /orP[/orP[/eqP ->|]|].
-    { exact: r_refl. }
-    { constructor. rewrite /t_closure. funelim (s_up_set n).
-      by rewrite mem_cat b. }
-    constructor. rewrite /t_closure. funelim (s_up_set n).
-    by rewrite mem_cat b. }
-  case=> [b |]; last exact: mem_head.
-  rewrite /t_closure in_cons. by funelim (s_up_set b) => ->.
+  move=> y x z /t_closureP xy /t_closureP yz.
+  apply /t_closureP /t_trans; first exact: xy; exact: yz.
 Qed.
 
-Lemma clos_t_clos_rt {R : rel T} a b :
-  clos_trans T R a b -> clos_refl_trans T R a b.
+Lemma rt_closureP x y :
+  reflect (clos_refl_trans T (sfrel f) x y) (rt_closure x y).
 Proof.
-  elim=> [|c d e ctcd crtcd ctde crtce]; first by constructor.
-  apply /rt_trans; first exact: crtcd. exact: crtce.
+  apply /equivP; last first.
+  { rewrite clos_refl_transE clos_reflE. 
+    apply or_iff_compat_l; symmetry.
+    apply rwP; exact: t_closureP. }
+  rewrite /t_closure /rt_closure /wsuffix in_cons eq_sym.
+  by apply predU1P.
 Qed.
 
-Lemma filter_clos_sub a b :
-  clos_trans_n1 T (sfrel f\eq) a b -> clos_trans_n1 T (sfrel f) a b.
+Lemma rt_closureE : rt_closure ≡ eq_op ⊔ t_closure.
+Proof. 
+  move=> x y /=; rewrite /rt_closure /t_closure. 
+  by rewrite /wsuffix in_cons eq_sym.
+Qed.
+
+Lemma rt_closure_lt : rt_closure ≦ (>=%O : rel T).
 Proof.
-  elim=> [c sfac | c d sfcd ctacn ctac].
-  { apply /tn1_step. move: sfac. auto. }
-  apply /tn1_trans; last exact: ctac. move: sfcd. auto.
+  rewrite rt_closureE.
+  move=> x y /orP[/eqP[<-]|] //=.
+  move=> /t_closure_lt; exact: ltW.
 Qed.
 
-Lemma refl_trans_refl_rt a b :
-  clos_refl_trans_n1 T (sfrel f) a b -> clos_refl T t_closure a b.
-Proof.
-  rewrite /sfrel /=. 
-  elim=> [|c d sfcd crtac /rt_closure_reflP rtac]; first exact: r_refl.
-  case: (c =P d) => [<-| /eqP neq].
-  { apply /rt_closure_reflP. 
-    case: (rt_closure_reflP a c rtac) => [e|]; last exact: mem_head.
-    by rewrite /rt_closure /up_set /t_closure in_cons => ->. }
-  constructor. apply /t_closureP. elim: crtac => //.
-  case: (a =P c) => [->|nac].
-  { constructor. auto. }
-  apply /t_trans.
-  { move: (rt_closure_reflP a c rtac) => /clos_reflE. case; first by [].
-  exact: t_closureP. }
-  constructor. auto.
-Qed.
-
-Lemma rt_closure_refl a : rt_closure a a.
+Lemma rt_closure_refl x : rt_closure x x.
 Proof. exact: mem_head. Qed.
 
-(* Reflexive-transitive closure reflection lemma *)
-Lemma rt_closure_n1P a b :
-  reflect (clos_refl_trans_n1 T (sfrel f) a b) (rt_closure a b).
+Lemma rt_closure_antisym : antisymmetric rt_closure.
 Proof.
-  apply /(iffP idP).
-  { move=> /rt_closure_reflP. case => [c /t_closure_n1P cac|]; last by constructor.
-    by apply /clos_rt_rtn1 /clos_t_clos_rt /clos_tn1_trans /filter_clos_sub. }
-  by move=> /refl_trans_refl_rt /rt_closure_reflP.
-Qed.
-
-Lemma rt_closureP a b :
-  reflect (clos_refl_trans T (sfrel f) a b) (rt_closure a b).
-Proof.
-  apply /(iffP idP).
-  { move=> /rt_closure_n1P. exact: clos_rtn1_rt. }
-  move=> rtab. apply /rt_closure_n1P. exact: clos_rt_rtn1.
+  move=> x y /andP[]. 
+  move=> /rt_closure_lt /= xy /rt_closure_lt /= yx. 
+  by apply /eqP; rewrite eq_le xy yx.
 Qed.
 
 Lemma rt_closure_trans : transitive rt_closure.
 Proof.
-  move=> b a c /rt_closureP ab /rt_closureP bc.
-  apply/rt_closureP /rt_trans; first exact: ab. done.
+  move=> y x z /rt_closureP xy /rt_closureP ?.
+  by apply/rt_closureP /rt_trans; first exact: xy. 
 Qed.
 
-Lemma rt_closure_lt a b : rt_closure a b -> a <= b.
-Proof.
-  rewrite /rt_closure /up_set in_cons => /orP[/eqP -> //|] asb.
-  rewrite le_eqVlt. apply /orP. right. by apply /t_closure_lt.
-Qed.
-
-Lemma rt_closure_antisym : antisymmetric rt_closure.
-Proof.
-  move=> a b /andP[] /rt_closure_lt ab /rt_closure_lt ba. apply /eqP.
-  by rewrite eq_le ab ba.
-Qed.
-
-End well_founded.
+End DescendRTClos.

--- a/relations.v
+++ b/relations.v
@@ -44,97 +44,9 @@ Proof.
   by rewrite /=mem_filter andbC eq_sym.
 Qed.
 
-(* Lemma strictify_weq_ f : *)
-(*   (sfrel (strictify f) : hrel T T) ≡ (sfrel f \ eq_op). *)
-(* Proof. move=> x y. by rewrite strictify_weq. Qed. *)
-
 Lemma strictify_leq f : 
   sfrel (strictify f) ≦ sfrel f.
 Proof. by rewrite strictify_weq; lattice. Qed.
-
-(* Lemma helper `{lattice.laws} `{NEG+CUP+CAP+TOP ≪ l} :  *)
-(*   forall x y, x ⊔ y \ x ≡ y. *)
-(* Proof.  *)
-(*   move=> x y. *)
-
-(*   move=> x y; apply /weq_spec; split. *)
-(*   { apply /cup_spec; split; last by lattice. *)
-(*     admit. } *)
-(*   have: (x ≡ x ⊓ y). *)
-(*   { symmetry. apply leq_iff_cap. admit. } *)
-(*   move=> tmp. rewrite -> tmp at 1. *)
-(*   rewrite capC. *)
-(*   have HH: (y ≡ y ⊓ top). *)
-(*   { admit. }  *)
-(*   rewrite -> HH at 1. *)
-(*   rewrite <- cupneg. *)
-(*   rewrite -> capcup_. *)
-(*   done. *)
-(* Qed   *)
-(*   rewrite leq_iff_cap. *)
-(*   have HH: (y ≡ y ⊓ top). *)
-(*   { admit. }  *)
-(*   rewrite -> HH at 1. *)
-(*   (* symmetry. apply: capxt. *) *)
-(*   rewrite <- cupneg. *)
-(*   rewrite -> capcup_. *)
-  
-(*   apply /leq_Transitive /leq_cup_r.  *)
-(*   apply /leq_Transitive; last first.  *)
-
-(*   apply: leq_cap_l. *)
-(*   rewrite leq_cup_r. *)
-(*   lattice. *)
-(*     move=> H. *)
-(*     red. simpl.    *)
-
-(* move=> x y  *)
-
-
-(* Lemma helper {L : lattice.ops} {l : level} `{NEG+CUP+CAP ≪ l} {LAWS : lattice.laws l L} :  *)
-(*   forall x y, x ⊔ y \ x ≡ y. *)
-(* Proof. move=> x y. apply /weq_spec. split. *)
-
-(* Lemma rc_strictify f : *)
-(*   clos_refl T (sfrel (strictify f)) ≡ clos_refl T (sfrel f). *)
-
-(* TODO: reformulate in terms of reflexive closure once 
- *   we'll generalize it to arbitary lattices with identity.
- * TODO: just use the lemma `cup_sub_one` once we'll resolve techinical 
- *   issues around ka instance for `rel T` (decidable relations).
- *)
-Lemma clos_refl_strictify f : 
-  eq_op ⊔ sfrel (strictify f) ≡ eq_op ⊔ sfrel f. 
-Proof. 
-  rewrite strictify_weq. 
-  apply weq_spec; split; first by lattice.
-  have {1}->: (sfrel f) ≡ (sfrel f) ⊓ top by symmetry; apply: capxt.
-  have -> : top ≡ eq_op ⊔ !eq_op.
-  { by move=> t x y /=; case: (x == y). }
-  by rewrite capcup; lattice.
-Qed.
-
-Lemma helper (r1 r2 : rel T) :
-  r1 ≡ r2 <-> (r1 : hrel T T) ≡ (r2 : hrel T T).
-Proof. 
-  split; move=> H x y; move: (H x y)=> /=.  
-  { by move=> <-. }
-  apply eq_bool_iff.
-Qed.
-
-Lemma clos_refl_trans_strictify f : 
-  (sfrel (strictify f) : hrel T T)^* ≡ (sfrel f : hrel T T)^*. 
-Proof. 
-  apply: kleene.str_weq1.
-  (* TODO: get rid of these dirty hacks *)
-  have ->: 1 + (sfrel (strictify f) : hrel T T) ≡ eq_op ⊔ sfrel (strictify f).
-  { move=> x y /=. 
-    apply: Bool.reflect_iff predU1P. }
-  have ->: 1 + (sfrel f : hrel T T) ≡ eq_op ⊔ sfrel f.
-  { move=> x y /=. 
-    apply: Bool.reflect_iff predU1P. }
-  by apply /helper /clos_refl_strictify.
-Qed.
 
 End SeqFunRel.
 

--- a/relations.v
+++ b/relations.v
@@ -1,6 +1,6 @@
 From Coq Require Import Relations Relation_Operators.
 From mathcomp Require Import ssreflect ssrbool ssrfun eqtype seq order.
-From RelationAlgebra Require Import lattice monoid rel.
+From RelationAlgebra Require Import lattice monoid rel kat_tac.
 From Equations Require Import Equations.
 From event_struct Require Import utilities wftype.
 
@@ -8,13 +8,12 @@ Set Implicit Arguments.
 Unset Printing Implicit Defensive.
 Set Equations Transparent.
 
-Import Order.LTheory.
-Local Open Scope order_scope.
-(* Local Open Scope ra_terms. *)
-
 (* a hack to bypass a shadowing problem caused by relation-algebra import *)
 Local Notation antisymmetric  := Coq.ssr.ssrbool.antisymmetric.
 Local Notation transitive := Coq.ssr.ssrbool.transitive.
+
+Import Order.LTheory.
+Local Open Scope order_scope.
 
 Declare Scope rel_scope.
 Delimit Scope rel_scope with REL.
@@ -27,25 +26,115 @@ Local Open Scope rel_scope.
  *)
 Reserved Notation "r °" (at level 5, left associativity, format "r °").
 
+
 Section SeqFunRel.
 
 Context {T : eqType}.
+Implicit Type (f : T -> seq T).
 
-Definition sfrel (f : T -> seq T) : rel T := [rel a b | b \in f a].
+Definition sfrel f : rel T := [rel a b | b \in f a].
 
-Definition strictify (f : T -> seq T) : T -> seq T :=
+Definition strictify f : T -> seq T :=
   fun n => filter^~ (f n) (fun x => x != n).
 
-Lemma strictify_weq (f : T -> seq T) :
+Lemma strictify_weq f :
   sfrel (strictify f) ≡ (sfrel f \ eq_op).
 Proof. 
   move=> x y. rewrite /sfrel /strictify //=.
   by rewrite /=mem_filter andbC eq_sym.
 Qed.
 
-Lemma strictify_leq (f : T -> seq T) : 
+(* Lemma strictify_weq_ f : *)
+(*   (sfrel (strictify f) : hrel T T) ≡ (sfrel f \ eq_op). *)
+(* Proof. move=> x y. by rewrite strictify_weq. Qed. *)
+
+Lemma strictify_leq f : 
   sfrel (strictify f) ≦ sfrel f.
 Proof. by rewrite strictify_weq; lattice. Qed.
+
+(* Lemma helper `{lattice.laws} `{NEG+CUP+CAP+TOP ≪ l} :  *)
+(*   forall x y, x ⊔ y \ x ≡ y. *)
+(* Proof.  *)
+(*   move=> x y. *)
+
+(*   move=> x y; apply /weq_spec; split. *)
+(*   { apply /cup_spec; split; last by lattice. *)
+(*     admit. } *)
+(*   have: (x ≡ x ⊓ y). *)
+(*   { symmetry. apply leq_iff_cap. admit. } *)
+(*   move=> tmp. rewrite -> tmp at 1. *)
+(*   rewrite capC. *)
+(*   have HH: (y ≡ y ⊓ top). *)
+(*   { admit. }  *)
+(*   rewrite -> HH at 1. *)
+(*   rewrite <- cupneg. *)
+(*   rewrite -> capcup_. *)
+(*   done. *)
+(* Qed   *)
+(*   rewrite leq_iff_cap. *)
+(*   have HH: (y ≡ y ⊓ top). *)
+(*   { admit. }  *)
+(*   rewrite -> HH at 1. *)
+(*   (* symmetry. apply: capxt. *) *)
+(*   rewrite <- cupneg. *)
+(*   rewrite -> capcup_. *)
+  
+(*   apply /leq_Transitive /leq_cup_r.  *)
+(*   apply /leq_Transitive; last first.  *)
+
+(*   apply: leq_cap_l. *)
+(*   rewrite leq_cup_r. *)
+(*   lattice. *)
+(*     move=> H. *)
+(*     red. simpl.    *)
+
+(* move=> x y  *)
+
+
+(* Lemma helper {L : lattice.ops} {l : level} `{NEG+CUP+CAP ≪ l} {LAWS : lattice.laws l L} :  *)
+(*   forall x y, x ⊔ y \ x ≡ y. *)
+(* Proof. move=> x y. apply /weq_spec. split. *)
+
+(* Lemma rc_strictify f : *)
+(*   clos_refl T (sfrel (strictify f)) ≡ clos_refl T (sfrel f). *)
+
+(* TODO: reformulate in terms of reflexive closure once 
+ *   we'll generalize it to arbitary lattices with identity.
+ * TODO: just use the lemma `cup_sub_one` once we'll resolve techinical 
+ *   issues around ka instance for `rel T` (decidable relations).
+ *)
+Lemma clos_refl_strictify f : 
+  eq_op ⊔ sfrel (strictify f) ≡ eq_op ⊔ sfrel f. 
+Proof. 
+  rewrite strictify_weq. 
+  apply weq_spec; split; first by lattice.
+  have {1}->: (sfrel f) ≡ (sfrel f) ⊓ top by symmetry; apply: capxt.
+  have -> : top ≡ eq_op ⊔ !eq_op.
+  { by move=> t x y /=; case: (x == y). }
+  by rewrite capcup; lattice.
+Qed.
+
+Lemma helper (r1 r2 : rel T) :
+  r1 ≡ r2 <-> (r1 : hrel T T) ≡ (r2 : hrel T T).
+Proof. 
+  split; move=> H x y; move: (H x y)=> /=.  
+  { by move=> <-. }
+  apply eq_bool_iff.
+Qed.
+
+Lemma clos_refl_trans_strictify f : 
+  (sfrel (strictify f) : hrel T T)^* ≡ (sfrel f : hrel T T)^*. 
+Proof. 
+  apply: kleene.str_weq1.
+  (* TODO: get rid of these dirty hacks *)
+  have ->: 1 + (sfrel (strictify f) : hrel T T) ≡ eq_op ⊔ sfrel (strictify f).
+  { move=> x y /=. 
+    apply: Bool.reflect_iff predU1P. }
+  have ->: 1 + (sfrel f : hrel T T) ≡ eq_op ⊔ sfrel f.
+  { move=> x y /=. 
+    apply: Bool.reflect_iff predU1P. }
+  by apply /helper /clos_refl_strictify.
+Qed.
 
 End SeqFunRel.
 

--- a/relations.v
+++ b/relations.v
@@ -1,6 +1,6 @@
 From Coq Require Import Relations Relation_Operators.
 From mathcomp Require Import ssreflect ssrbool ssrfun eqtype seq order.
-From RelationAlgebra Require Import lattice rel.
+From RelationAlgebra Require Import lattice monoid rel.
 From Equations Require Import Equations.
 From event_struct Require Import utilities wftype.
 
@@ -80,11 +80,11 @@ Implicit Type (R : relation T) (r : rel T).
 
 Lemma rel_cnvE r y : 
   rel_cnv r y = r^~ y.
-Proof. by rewrite /cnv. Qed.
+Proof. by rewrite /rel_cnv. Qed.
 
 Lemma rel_cnvP R r : 
   (forall x y, reflect (R x y) (r x y)) -> 
-  forall x y, reflect ((R : hrel _ _)°%ra x y) (r° x y).
+  forall x y, reflect ((R : hrel T T)°%ra x y) (r° x y).
 Proof.
   move=> H x y; move: (H y x)=> /rwP [f g] /=. 
   by apply: Bool.iff_reflect. 

--- a/utilities.v
+++ b/utilities.v
@@ -307,7 +307,7 @@ Proof. move=> H; split=> [][] x /H ?; by exists x. Qed.
 Section RelAux.
 
 Context {T : Type}.
-Implicit Types (R : relation T).
+Implicit Types (R : relation T) (r : rel T).
 
 Lemma clos_reflE R :
   clos_refl T R ≡ 1 ⊔ (R : hrel T T).

--- a/utilities.v
+++ b/utilities.v
@@ -4,6 +4,12 @@ From mathcomp Require Import seq path fingraph fintype.
 From RelationAlgebra Require Import lattice boolean.
 
 (* ************************************************************************** *)
+(*     Missing notations for Relation Algebra                                 *)
+(* ************************************************************************** *)
+
+Notation "x \ y" := (x ⊓ !y) (right associativity, at level 30): ra_terms.
+
+(* ************************************************************************** *)
 (*     Some automation with hints and tactics                                 *)
 (* ************************************************************************** *)
 

--- a/utilities.v
+++ b/utilities.v
@@ -4,12 +4,6 @@ From mathcomp Require Import seq path fingraph fintype.
 From RelationAlgebra Require Import lattice monoid boolean rel kat_tac.
 
 (* ************************************************************************** *)
-(*     Missing notations for Relation Algebra                                 *)
-(* ************************************************************************** *)
-
-Notation "x \ y" := (x ⊓ !y) (right associativity, at level 30): ra_terms.
-
-(* ************************************************************************** *)
 (*     Some automation with hints and tactics                                 *)
 (* ************************************************************************** *)
 
@@ -235,19 +229,8 @@ Qed.
 End SeqIn.
 
 (* ************************************************************************** *)
-(*     Cartesian product for lattice-valued functions                         *)
+(*     Missing definition, notations and lemmas for Relation Algebra          *)
 (* ************************************************************************** *)
-
-Section CartesianProd.
-
-Context {T : Type} {L : lattice.ops}.
-
-Definition cart_prod (p q : T -> L) : T -> T -> L :=
-  fun x y => p x ⊓ q y.
-
-End CartesianProd.
-
-Notation "p × q" := (cart_prod p q) (at level 60, no associativity) : ra_terms.
 
 (* ************************************************************************** *)
 (*     Reflexive closure for decidable relations                              *)
@@ -273,6 +256,49 @@ End ReflexiveClosure.
 
 Notation "r ^?" := (rtc r) (left associativity, at level 5, format "r ^?"): ra_terms.
 
+(* ************************************************************************** *)
+(*     Subtraction (for complemented lattices, i.e. lattices with negation)   *)
+(* ************************************************************************** *)
+
+Notation "x \ y" := (x ⊓ !y) (right associativity, at level 30): ra_terms.
+
+Section SubtractionTheory.
+
+Context `{monoid.laws} (n : ob X).
+Implicit Types (x : X n n). 
+
+(* TODO: introduce a class of lattices/kleene-algebras 
+ *   with decidable equality? *)
+Context (eq_dec : 1 ⊔ !1 ≡ (top : X n n)).
+
+(* TODO: reformulate in terms of reflexive closure once 
+ *   we'll generalize it to arbitary lattices with identity.
+ *)
+Lemma cup_sub_one `{CUP+CAP+TOP ≪ l} :
+  forall x, 1 ⊔ x \ 1 ≡ 1 ⊔ x.
+Proof. 
+  move=> x; apply weq_spec; split; first by lattice.
+  have {1}->: x ≡ x ⊓ top by symmetry; apply: capxt.
+  by rewrite -eq_dec capcup; lattice.
+Qed.
+
+End SubtractionTheory. 
+
+(* ************************************************************************** *)
+(*     Cartesian product for lattice-valued functions                         *)
+(* ************************************************************************** *)
+
+Section CartesianProd.
+
+Context {T : Type} {L : lattice.ops}.
+
+Definition cart_prod (p q : T -> L) : T -> T -> L :=
+  fun x y => p x ⊓ q y.
+
+End CartesianProd.
+
+Notation "p × q" := (cart_prod p q) (at level 60, no associativity) : ra_terms.
+
 Lemma exists_equiv {T} {A B : T -> Prop} :
   (forall x, A x <-> B x) -> (exists x, A x) <-> exists x, B x.
 Proof. move=> H; split=> [][] x /H ?; by exists x. Qed.
@@ -290,6 +316,9 @@ Proof.
   case=> [->|]; first exact: r_refl; exact: r_step.
 Qed.
 
+(* TODO: consider to reformulate it in terms of relation-algebra 
+ * (or try to just use kat tactics inplace) 
+ *)
 Lemma clos_t_clos_rt R x y :
   clos_trans T R x y -> clos_refl_trans T R x y.
 Proof.
@@ -297,6 +326,7 @@ Proof.
   by apply /rt_trans; first exact: H. 
 Qed.
 
+(* TODO: consider to replace it to `str_itr` *)
 Lemma clos_refl_transE R :
   clos_refl_trans T R ≡ clos_refl T (clos_trans T R).
 Proof.


### PR DESCRIPTION
The purpose of that PR was to refactor `relations.v` to simplify the theory and remove redundant lemmas and to try our relation-algebra library. On the way I was forced to fix some proofs in `eventstructure.v` and `transitionsystem.v` and most likely I did in a suboptimal way. These changes enlarged the diff, sorry for that :(
I think we'll need to revisit the proofs in these files (`eventstructure.v` and `transitionsystem.v`) at some point later and try to make them a bit more modular. 

A short summary of changes in this PR. 

1. `utilities.v`: ~~add lemmas `seq_in_mem` and `seq_in_mem_exists` for `seq_in` theory~~ (see https://github.com/volodeyka/event-struct/pull/63)
2. `utilities.v`: ~~add notation `x \ y` subtraction for lattices~~ (see https://github.com/volodeyka/event-struct/pull/62)
3. `utilities.v`: ~~add lemmas to bridge `clos_refl`, `clos_trans`, etc (from vanilla Coq library) with their counterparts from relation-algebra~~ (see https://github.com/volodeyka/event-struct/pull/64)
4. `relations.v`: ~~rename `strict` into `strictify` (verb form, the name is debatable), prove `strictify_weq` and `strictify_leq` lemmas for `strictify` elimination in proofs~~ (see https://github.com/volodeyka/event-struct/pull/68)
5. ~~change the "direction" of `sfrel f`, i.e. `sfrel f == { <x , f x> }` ~~ (see https://github.com/volodeyka/event-struct/pull/83)
6. `relations.v`: ~~introduce `rel_cnv` --- conversion (i.e. transposition, inversion) for decidable relations (`rel T`). This is a temporary solution until I'll fix the technical issues in relation-algebra. At that point we will be able to use its notation and theory of converse~~ (see https://github.com/volodeyka/event-struct/pull/83). 
7. `relations.v`: ~~rename `s_up_set` --> `suffix`, `up_set` --> `wsuffix` (weak/reflexive version)~~ (see https://github.com/volodeyka/event-struct/pull/71)
8. `relations.v`: ~~simplify the theory of `t_closure` and `rt_closure`. Leave only reflection lemmas, `_ge`/`_gt`, and lemmas about relation-properties (reflexivity, transitivity, etc)~~ (see https://github.com/volodeyka/event-struct/pull/71)

I hope the list of changes above will help the reviewers to get through the diff. 
Again, sorry for bringing a lot of things into one PR. 
In case someone has serious concerns w.r.t. particular changes, I can try to isolate them into separate PR for further discussion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volodeyka/event-struct/61)
<!-- Reviewable:end -->
