### PR TITLE
Monoid and Partial Monoid

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -10,6 +10,7 @@
 -arg -w -arg -ambiguous-paths
 
 utilities.v
+monoid.v
 inhtype.v
 wftype.v
 relations.v

--- a/monoid.v
+++ b/monoid.v
@@ -1,0 +1,118 @@
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq eqtype choice. 
+From RelationAlgebra Require Import monoid.
+
+From event_struct Require Import utilities.
+
+(******************************************************************************)
+(* This file provides a theory of (homogeneous) monoids and partial monoids.  *)
+(*                                                                            *)
+(*       Monoid.m T     == a type of monoidal structures over elements        *)
+(*                         of type T. Consists of binary associative          *)
+(*                         operation and a neutral element (unit).            *) 
+(*       Monoid.mType d == a type equipped with canonical monoidal structure. *)
+(*                                                                            *)
+(*       Monoid.pm d     == a type of monoidal structures with partial        *) 
+(*                          operation over elements of type T.                *)
+(*                          Inherits from ordinary monoidal structure.        *)
+(*                          In addition, contains a binary validity relation  *)  
+(*                          which determines pairs of elements whose          *)
+(*                          composition is defined.                           *) 
+(*       Monoid.pmType d == a type equipped with canonical partial            *)
+(*                          monoidal structure.                               *)
+(******************************************************************************)
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Declare Scope monoid_scope.
+Delimit Scope monoid_scope with monoid.
+
+Local Open Scope monoid_scope.
+
+Reserved Notation "x \+ y" (at level 40, left associativity).
+Reserved Notation "x \+? y" (at level 20, no associativity).
+
+Module Monoid.
+
+Module Monoid.
+Section ClassDef. 
+
+Record mixin_of (T : Type) := Mixin {
+  id : T;
+  op : T -> T -> T;
+  _  : associative op;
+  _  : left_id id op;
+  _  : right_id id op;
+}.
+
+Notation class_of := mixin_of (only parsing). 
+
+Structure type (disp : unit) := Pack { sort; _ : class_of sort }.
+
+Local Coercion sort : type >-> Sortclass.
+
+Variables (T : Type) (disp : unit) (cT : type disp).
+
+Definition class := let: Pack _ c as cT' := cT return class_of (sort cT') in c.
+
+Definition pack c := @Pack disp T c.
+
+Definition clone c of phant_id class c := @Pack disp T c.
+Definition clone_with disp' c of phant_id class c := @Pack disp' T c.
+
+End ClassDef.
+
+Module Exports.
+Coercion sort : type >-> Sortclass.
+End Exports.
+
+End Monoid.
+
+Notation m     := Monoid.mixin_of.
+Notation mType := Monoid.type.
+
+Import Monoid.Exports.
+
+Module Import MonoidDef.
+Section MonoidDef.
+
+Context {disp : unit} {M : mType disp}.
+
+Definition id : M := Monoid.id (Monoid.class M).
+Definition op : M -> M -> M := Monoid.op (Monoid.class M).
+
+End MonoidDef.
+End MonoidDef.
+
+Prenex Implicits op id.
+
+Module Export MonoidSyntax.
+Notation "x \+ y" := (op x y) : monoid_scope.
+End MonoidSyntax.
+
+Module Export MonoidTheory.
+Section MonoidTheory.
+
+Context {disp : unit} {M : mType disp}.
+
+Lemma opA (x y z : M) : 
+  x \+ y \+ z = x \+ (y \+ z). 
+Proof. by move: x y z; case: M=> ? []. Qed.
+
+Lemma idL (x : M) : 
+  id \+ x = x. 
+Proof. by move: x; case: M=> ? []. Qed.
+
+Lemma idR (x : M) : 
+  x \+ id = x. 
+Proof. by move: x; case: M=> ? []. Qed.
+
+End MonoidTheory.
+End MonoidTheory.
+
+End Monoid.
+
+Export Monoid.MonoidDef.
+Export Monoid.MonoidSyntax.
+Export Monoid.MonoidTheory.

--- a/monoid.v
+++ b/monoid.v
@@ -103,7 +103,7 @@ Section MonoidTheory.
 
 Context {disp : unit} {M : mType disp}.
 
-Lemma plusAA (x y z : M) : 
+Lemma plusA (x y z : M) : 
   x \+ y \+ z = x \+ (y \+ z). 
 Proof. by case: M x y z => ? [[]]. Qed.
 

--- a/monoid.v
+++ b/monoid.v
@@ -14,7 +14,7 @@ From event_struct Require Import utilities.
 (*       Monoid.pm d     == a type of monoidal structures with partial        *) 
 (*                          operation over elements of type T.                *)
 (*                          Inherits from ordinary monoidal structure.        *)
-(*                          In addition, contains a binary validity relation  *)  
+(*                          In addition, contains a orthogonality relation    *)  
 (*                          which determines pairs of elements whose          *)
 (*                          composition is defined.                           *) 
 (*       Monoid.pmType d == a type equipped with canonical partial            *)
@@ -31,7 +31,7 @@ Delimit Scope monoid_scope with monoid.
 Local Open Scope monoid_scope.
 
 Reserved Notation "x \+ y" (at level 40, left associativity).
-Reserved Notation "x \+? y" (at level 20, no associativity).
+Reserved Notation "x ⊥ y" (at level 20, no associativity).
 
 Module Monoid.
 
@@ -46,7 +46,11 @@ Record mixin_of (T : Type) := Mixin {
   _  : right_id id op;
 }.
 
-Notation class_of := mixin_of (only parsing). 
+Set Primitive Projections.
+Record class_of (T : Type) := Class {
+  mixin : mixin_of T;
+}.
+Unset Primitive Projections.
 
 Structure type (disp : unit) := Pack { sort; _ : class_of sort }.
 
@@ -64,12 +68,13 @@ Definition clone_with disp' c of phant_id class c := @Pack disp' T c.
 End ClassDef.
 
 Module Exports.
+Coercion mixin : class_of >-> mixin_of.
 Coercion sort : type >-> Sortclass.
 End Exports.
 
 End Monoid.
 
-Notation m     := Monoid.mixin_of.
+Notation m     := Monoid.class_of.
 Notation mType := Monoid.type.
 
 Import Monoid.Exports.
@@ -98,21 +103,138 @@ Context {disp : unit} {M : mType disp}.
 
 Lemma opA (x y z : M) : 
   x \+ y \+ z = x \+ (y \+ z). 
-Proof. by move: x y z; case: M=> ? []. Qed.
+Proof. by move: x y z; case: M=> ? [[]]. Qed.
 
 Lemma idL (x : M) : 
   id \+ x = x. 
-Proof. by move: x; case: M=> ? []. Qed.
+Proof. by move: x; case: M=> ? [[]]. Qed.
 
 Lemma idR (x : M) : 
   x \+ id = x. 
-Proof. by move: x; case: M=> ? []. Qed.
+Proof. by move: x; case: M=> ? [[]]. Qed.
 
 End MonoidTheory.
 End MonoidTheory.
+
+Module PartialMonoid.
+Section ClassDef. 
+
+Record mixin_of (T0 : Type) (b : Monoid.class_of T0)
+                (T := Monoid.Pack tt b) := Mixin {
+  orth : rel T;
+  _    : orth id id;
+  _    : forall x, orth x id <-> orth id x;
+  _    : forall x y, orth x y -> orth x id;
+  _    : forall x y z, orth x y -> orth (op x y) z -> orth y z && orth x (op y z);
+}.
+
+Set Primitive Projections.
+Record class_of (T : Type) := Class {
+  base  : Monoid.class_of T;
+  mixin : mixin_of base;
+}.
+Unset Primitive Projections.
+
+Local Coercion base : class_of >-> Monoid.class_of.
+
+Structure type (disp : unit) := Pack { sort; _ : class_of sort }.
+
+Local Coercion sort : type >-> Sortclass.
+
+Variables (T : Type) (disp : unit) (cT : type disp).
+
+Definition class := let: Pack _ c as cT' := cT return class_of (sort cT') in c.
+
+Definition pack :=
+  fun bE b & phant_id (@Monoid.class disp bE) b =>
+  fun m => Pack disp (@Class T b m).
+
+Definition mType := @Monoid.Pack disp cT class.
+End ClassDef.
+
+Module Exports.
+Coercion base : class_of >-> Monoid.class_of.
+Coercion mixin : class_of >-> mixin_of.
+Coercion sort : type >-> Sortclass.
+Coercion mType : type >-> Monoid.type.
+Canonical mType.
+End Exports.
+
+End PartialMonoid.
+
+Notation pm     := PartialMonoid.class_of.
+Notation pmType := PartialMonoid.type.
+
+Import PartialMonoid.Exports.
+
+Module Import PartialMonoidDef.
+Section PartialMonoidDef.
+
+Context {disp : unit} {M : pmType disp}.
+
+Definition orth : rel M := PartialMonoid.orth (PartialMonoid.class M).
+
+Definition valid : pred M := fun x => orth x id.
+
+End PartialMonoidDef.
+End PartialMonoidDef.
+
+Prenex Implicits orth valid.
+
+Module Export PartialMonoidSyntax.
+Notation "x ⊥ y" := (orth x y) : monoid_scope.
+End PartialMonoidSyntax.
+
+Module Export PartialMonoidTheory.
+Section PartialMonoidTheory.
+
+Context {disp : unit} {M : pmType disp}.
+
+Lemma orth_id : 
+  orth id (id : M). 
+Proof. by case: M=> ? [? []]. Qed.
+
+Lemma valid_id : 
+  valid (id : M). 
+Proof. by case: M=> ? [? []]. Qed.
+
+Lemma orth_id_sym (x : M) :
+  x ⊥ id <-> id ⊥ x.
+Proof. by move: x; case: M=> ? [? []]. Qed.
+
+Lemma orthA (x y z : M) : 
+  x ⊥ y -> (x \+ y) ⊥ z -> y ⊥ z && x ⊥ (y \+ z).
+Proof. by move: x y z; case: M=> ? [? []]. Qed.
+
+Lemma orth_validL (x y : M) : 
+  x ⊥ y -> valid x. 
+Proof. by move: x y; case: M=> ? [? []]. Qed.
+
+Lemma orth_validR (x y : M) :
+  x ⊥ y -> valid y.
+Proof. 
+  move=> /[dup] /orth_validL. 
+  rewrite -{2}[x]idR=> /orthA /[apply].
+  by move=> /andP [/orth_id_sym ?]. 
+Qed.
+
+Lemma orth_valid_op (x y : M) : 
+  x ⊥ y -> valid (x \+ y). 
+Proof.
+  move=> /[dup] /orth_validL /orth_id_sym.
+  rewrite -{2}[x]idL=> /orthA /[apply].
+  by move=> /andP [? /orth_id_sym]. 
+Qed.
+
+End PartialMonoidTheory.
+End PartialMonoidTheory.
 
 End Monoid.
 
 Export Monoid.MonoidDef.
 Export Monoid.MonoidSyntax.
 Export Monoid.MonoidTheory.
+
+Export Monoid.PartialMonoidDef.
+Export Monoid.PartialMonoidSyntax.
+Export Monoid.PartialMonoidTheory.

--- a/monoid.v
+++ b/monoid.v
@@ -31,7 +31,7 @@ Delimit Scope monoid_scope with monoid.
 Local Open Scope monoid_scope.
 
 Reserved Notation "x \+ y" (at level 40, left associativity).
-Reserved Notation "x ⊥ y" (at level 20, no associativity).
+Reserved Notation "x ⟂ y" (at level 20, no associativity).
 
 Module Monoid.
 
@@ -103,7 +103,7 @@ Context {disp : unit} {M : mType disp}.
 
 Lemma opA (x y z : M) : 
   x \+ y \+ z = x \+ (y \+ z). 
-Proof. by move: x y z; case: M=> ? [[]]. Qed.
+Proof. by case: M x y z => ? [[]]. Qed.
 
 Lemma idL (x : M) : 
   id \+ x = x. 
@@ -123,9 +123,9 @@ Record mixin_of (T0 : Type) (b : Monoid.class_of T0)
                 (T := Monoid.Pack tt b) := Mixin {
   orth : rel T;
   _    : orth id id;
-  _    : forall x, orth x id <-> orth id x;
-  _    : forall x y, orth x y -> orth x id;
-  _    : forall x y z, orth x y -> orth (op x y) z -> orth y z && orth x (op y z);
+  _    : forall x, orth x id = orth id x;
+  _    : forall x y, orth x y -> orth x id && orth y id;
+  _    : forall x y z, orth (op x y) z = orth x (op y z);
 }.
 
 Set Primitive Projections.


### PR DESCRIPTION
This PR features the monoid and partial monoid structures (the latter inherits from the former). The partial monoid is intended to be a base class for synchronization algebra later #59. Partiality is encoded using the binary orthogonality relation (see [1] for details).

Why did we decide to invent the wheel here? Below are alternative formalizations of monoids and the reasons why we abandoned them. 

1) [mathcomp](https://github.com/math-comp/math-comp/blob/17dd3091e7f809c1385b0c0be43d1f8de4fa6be0/mathcomp/ssreflect/bigop.v#L328) 
Here the monoids are used primarily in the context of so-called big operations. The canonical instances are linked to operations themselves rather than to types. We decided that for our use cases, it makes more sense to attach the instance to the type. 

2) [relation-algebra](https://github.com/damien-pous/relation-algebra/blob/a9d903935d2f8681905628a814664f004760c676/monoid.v#L29)
Relation-Algebra has a very heavyweight notion of "monoid". First, it uses its own tricks to pack several operations into one structure and then enable/disable modularly (see this [file](https://github.com/damien-pous/relation-algebra/blob/a9d903935d2f8681905628a814664f004760c676/level.v#L17)). This design has some advantages but overall it seems too complex for our needs. Also, relation-algebra has heterogeneous typed monoids, which is also an overkill for us. 

3) [fcsl-pcm](https://github.com/imdea-software/fcsl-pcm/blob/4343e51d2f365ca75fd4a57cadf166b7850bdb36/pcm/pcm.v#L34)
In fcsl-pcm package, the PCMs (partial **commutative** monoids) are at the top of the hierarchy. We don't want to enforce commutativity for our synchronization algebras. Besides that, we've decided to try out the alternative encoding of partiality through the orthogonality relation, instead of validity predicate. 

**Question** 

Let's discuss a couple of questions about this PR. 

1) I used the notation `\+` for the monoidal operation (borrowed from fcsl-pcm package) and `id` for the unit. 
Do we have better suggestions? My minor concern, is that `id` is shorthand for identity, but using `\+` and `1` as a unit of monoid a bit frustrating... Also, perhaps we want a notation for the unit, like `0`, `1`, or `\eps` etc?

2) For the orthogonality I picked the `\perp` latex notation (Unicode)? Any alternative suggestions?

3) Also, we got some inspiration from fcsl-pcm, so perhaps we should mention the authors? What is a proper way to do this? @anton-trunov 

[1] Bart Jacobs --- [Convexity, Duality and Effects](https://core.ac.uk/download/pdf/191341277.pdf)