### PR TITLE
Adding lemmas for checking acyclicity of finite function

### DIFF
--- a/eventstructure.v
+++ b/eventstructure.v
@@ -38,7 +38,7 @@ From event_struct Require Import utilities relations wftype ident.
 
 Import Order.LTheory.
 Open Scope order_scope.
-
+Import WfClosure.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/relations.v
+++ b/relations.v
@@ -266,7 +266,7 @@ Proof.
 Qed.
 
 Inductive fdfs_path x y : Prop :=
-  FDfsPath p of path (fun x => sfrel f ^~ x) x p & y = last x p.
+  FDfsPath p of path (fun a => sfrel f ^~ a) x p & y = last x p.
 
 Lemma fdfs_dom_Nmem x y n: x \notin F -> y \in F ->
   y \notin fdfs n [::] x.

--- a/relations.v
+++ b/relations.v
@@ -221,6 +221,7 @@ Definition hack_f : F -> seq F :=
 Fixpoint fdfs n v x :=
   if x \in v then v else
   if n is n'.+1 then foldl (fdfs n') (x :: v) (f x) else v.
+  
 
 Definition equiv (x : T) (y : F) := x == fsval y.
 
@@ -318,10 +319,15 @@ Qed.
 
 Definition wsuffix x := fdfs n [::] x.
 
+Definition suffix x := flatten [seq f y | y <- wsuffix x].
+
 Definition rt_closure : rel T := 
   fun x y => x \in wsuffix y.
 
-Lemma t_closure_n1P x y : 
+Definition t_closure : rel T := 
+  fun x y => x \in suffix y.
+
+Lemma rt_closure_n1P x y : 
   reflect (clos_refl_trans_n1 T (sfrel f) x y) (rt_closure x y).
 Proof.
   apply/(equivP (fdfsP y x)); split=> [[p]|].
@@ -329,6 +335,26 @@ Proof.
     move=> a > IHp > /andP[? /IHp /[apply] ?]; exact/(rtn1_trans _ _ _ a).
   elim=> [|z ??? [p *]]; first by exists [::].
   exists (z :: p)=> //; exact/andP.
+Qed.
+
+Arguments clos_rtn1_rt {_ _ _ _}.
+Arguments clos_rt_rtn1 {_ _ _ _}.
+Arguments clos_trans_tn1 {_ _ _ _}.
+Arguments clos_trans_t1n {_ _ _ _}.
+Arguments clos_tn1_trans {_ _ _ _}.
+Arguments clos_t1n_trans {_ _ _ _}.
+Arguments clos_t_clos_rt {_ _ _ _}.
+Arguments t1n_trans _ {_ _ _ _}.
+
+Lemma t_closure_n1P x y: 
+  reflect (clos_trans_n1 T (sfrel f) x y) (t_closure x y).
+Proof.
+  apply: (iffP flatten_mapP)=> [[? /rt_closure_n1P /clos_rtn1_rt]|].
+  - rewrite clos_refl_transE=> [[? /clos_trans_t1n ? R|]]; last by constructor.
+    exact/clos_trans_tn1/clos_t1n_trans/(t1n_trans T R).
+  case/clos_tn1_trans/clos_trans_t1n=> [z ?|w ??].
+  - exists z=> //; apply/rt_closure_n1P; by constructor.
+  move/clos_t1n_trans/clos_t_clos_rt/clos_rt_rtn1/rt_closure_n1P; by exists w.
 Qed.
 
 End FinRTClosure.

--- a/relations.v
+++ b/relations.v
@@ -42,6 +42,8 @@ Local Open Scope ra_terms.
 Definition sfrel {T : eqType} (f : T -> seq T) : rel T :=
   [rel a b | a \in f b].
 
+
+
 Section Strictify.
 
 Context {T : eqType}.
@@ -62,6 +64,8 @@ Lemma strictify_leq f :
 Proof. by rewrite strictify_weq; lattice. Qed.
 
 End Strictify. 
+
+Module WfClosure.
 
 Section WfRTClosure.
 
@@ -320,15 +324,22 @@ Proof.
   exact/fdfsE.
 Qed.
 
-Definition fsuffix x := fdfs (#|` F|) [::] x.
+Definition wsuffix x := fdfs n [::] x.
 
-Definition acyclic x := x \notin fsuffix x.
+Definition rt_closure : rel T := 
+  fun x y => x \in wsuffix y.
 
-Theorem acyclicP: 
-  reflect 
-  (forall x, ~ (clos_trans T (sfrel f) x x)) 
-  [forall x : F, acyclic (fsval x)].
-Admitted.
+Lemma t_closure_n1P x y : 
+  reflect (clos_refl_trans_n1 T (sfrel f) x y) (rt_closure x y).
+Proof.
+  apply/(equivP (fdfsP y x)); split=> [[p]|].
+  - elim: p x y=> //= [>_->|]; first by constructor.
+    move=> a > IHp > /andP[? /IHp /[apply] ?]; exact/(rtn1_trans _ _ _ a).
+  elim=> [|z ??? [p *]]; first exact/(FDfsPath _ [::]).
+  apply/(FDfsPath _ (z :: p))=> //; exact/andP.
+Qed.
 
-End Acyclic.
+End FinRTClosure.
+
+End FinClosure.
 

--- a/relations.v
+++ b/relations.v
@@ -197,7 +197,7 @@ Open Scope fset_scope.
 
 Variables (T : choiceType) (f : {fsfun T -> seq T with [::]}).
 
-Notation F := (finsupp f `|` [fset t | k in finsupp f, t in f k]).
+Definition F := (finsupp f `|` [fset t | k in finsupp f, t in f k]).
 Notation n := (#|`F|).
 
 Lemma memF {x y}: y \in f x -> y \in F.
@@ -218,11 +218,14 @@ Lemma l (v : seq F) x: x \in v = (fsval x \in [seq fsval x | x <- v]).
 Proof.
 Admitted.
 
-Lemma fdfsE n v x: 
-  [seq fsval x | x <- dfs hack_f n v x] =i fdfs n [seq fsval x | x <- v] (fsval x).
+Lemma fdfsE n (v : seq F) (x : F) : 
+  [seq fsval x | x <- dfs hack_f n v x] =
+  fdfs n [seq fsval x | x <- v] (fsval x).
 Proof.
-  elim n=> y //=; first by (do ?case: ifP).
-  (do ? case: ifP=> //)=> E; rewrite l ?E // => _.
+  elim: n v x=> n IHn //=; first by (do ?case: ifP).
+  move=> v x.
+  (do ? case: ifP=> //)=> E; rewrite l ?E //.
+  Search foldr.
 Admitted.
 
 Inductive fdfs_path x y : Prop :=

--- a/utilities.v
+++ b/utilities.v
@@ -383,3 +383,30 @@ End ReflectConnectives.
 
 Notation "'do' i <- s ; E" := (flatten (map (fun i => E) s)) (at level 10, i pattern).
 
+Section RelationOnSeq.
+
+Lemma rfoldl {A B C D} (r : A -> C -> bool) (r' : B -> D -> bool) 
+  (f : A -> B -> A) (f' : C -> D -> C) (bs : seq B) (ds : seq D)
+  (ini : A) (ini' : C) : r ini ini' ->
+  (forall a b c d, r a c -> r' b d -> r (f a b) (f' c d)) ->
+  all2 r' bs ds -> r (foldl f ini bs) (foldl f' ini' ds).
+Proof.
+  move=> + H.
+  elim: bs ini ini' ds=> [??[]//|?? IHbs ?? []//= ??? /andP[*]].
+  by apply/IHbs; first exact/H.
+Qed.
+
+Lemma rpath {T S} (sf : T -> S -> bool)  (r' : rel S) (y : S)
+  (s : seq S) (r : rel T) (t : seq T) (x : T) : sf x y ->
+  (forall a b c d, sf a c -> sf b d -> r a b = r' c d) ->
+  all2 sf t s -> 
+  path r x t = path r' y s.
+Proof.
+  move=> + H.
+  elim: t x y s=> [??[]//|/=> IHt ?? []//=> /H R /andP[/[dup] /IHt IH+/IH]].
+  by move/R->=>->.
+Qed.
+
+End RelationOnSeq.
+
+


### PR DESCRIPTION
To check acyclicity of finite function (`fsfun`) we should fist define it's transitive closure
Consider we have some `f : {fsfun : K -> V with dflt}` with is not decreasing. Clearly, `sfrel f` is not well-founded but we steel can define it's transitive closure.  
Here in SSReflect we 
https://github.com/math-comp/math-comp/blob/8e859e628404c50c8191f30489abf4e799f46f8d/mathcomp/ssreflect/fingraph.v#L48-L75
definition of `dfs` and some helpful lemmas.  Unfortunately we can't use such a definition because we have `fsfun` but not function of type (`T -> seq T`), where `T : finType`. Here I propose a way to use mathcomp's `dfs` to solve our goal: we should define our `dfs` version (`fdfs` here) and show that it is equivalent to original `dfs`. But I faced with rather technically difficult proofs and I hope that we can somehow avoid them. May be you can come up with a better way to solve it?
In this PR there are some admitted lemmas (my plan to prove `acyclicP`).

PS. of course we can define transitive closure like `clos_trans f x y= [exists z : finsupp f, f x = z && clos_trans f z y]` but `dfs` should work much faster.